### PR TITLE
Bugfix that prevented the user from saving his preferences

### DIFF
--- a/web/application/controllers/prefs.php
+++ b/web/application/controllers/prefs.php
@@ -107,7 +107,7 @@ class Prefs extends MY_Controller
      */
     function save() {
         $calendar = $this->input->post('calendar', true);
-        $default_calendar = $this->input->post('default_calendar', 'true');
+        $default_calendar = $this->input->post('default_calendar', true);
 
         if (!is_array($calendar)) {
             log_message('ERROR',


### PR DESCRIPTION
Bugfix that prevented the user from saving his preferences. The default-calendar was never fetched correctly and the user got an error message whatever he chose.
