### PR TITLE
per-user timezone, dialog_generator.php had changed from 1.2.6.2, but i ...

### DIFF
--- a/web/application/controllers/event.php
+++ b/web/application/controllers/event.php
@@ -53,8 +53,12 @@ class Event extends MY_Controller
         $this->date_format = DateHelper::getDateFormatFor('date', $this->date_format_pref);
         $this->time_format = DateHelper::getTimeFormatFor('date', $this->time_format_pref);
 
-        $this->tz = $this->timezonemanager->getTz(
+        if ($this->prefs->__get('timezone')) {
+            $this->tz = $this->timezonemanager->getTz($this->prefs->__get('timezone'));
+        } else {
+            $this->tz = $this->timezonemanager->getTz(
                 $this->config->item('default_timezone'));
+        }
         $this->tz_utc = $this->timezonemanager->getTz('UTC');
 
         $this->output->set_content_type('application/json');

--- a/web/application/libraries/Icshelper.php
+++ b/web/application/libraries/Icshelper.php
@@ -40,8 +40,13 @@ class Icshelper {
         $this->CI =& get_instance();
 
         // Timezone
-        $this->tz = $this->CI->timezonemanager->getTz(
-                $this->CI->config->item('default_timezone'));
+        $prefs = Preferences::singleton($this->CI->session->userdata('prefs'));
+        if ($prefs->__get('timezone')) {
+            $this->tz = $this->CI->timezonemanager->getTz($prefs->__get('timezone'));
+        } else {
+            $this->tz = $this->CI->timezonemanager->getTz(
+                    $this->CI->config->item('default_timezone'));
+        }
 
         $this->date_frontend_format_pref = $this->CI->config->item('default_date_format');
         $this->time_frontend_format_pref = $this->CI->config->item('default_time_format');

--- a/web/application/libraries/recurrence.php
+++ b/web/application/libraries/recurrence.php
@@ -34,8 +34,13 @@ class Recurrence {
         $this->date_format_pref = $this->CI->config->item('default_date_format');
         $this->time_format_pref = $this->CI->config->item('default_time_format');
         $this->date_format = DateHelper::getDateFormatFor('date', $this->date_format_pref);
-        $this->tz = $this->CI->timezonemanager->getTz(
-                $this->CI->config->item('default_timezone'));
+        $prefs = Preferences::singleton($this->CI->session->userdata('prefs'));
+        if ($prefs->__get('timezone')) {
+            $this->tz = $this->CI->timezonemanager->getTz($prefs->__get('timezone'));
+        } else {
+            $this->tz = $this->CI->timezonemanager->getTz(
+                    $this->CI->config->item('default_timezone'));
+        }
     }
 
     /**


### PR DESCRIPTION
per-user timezone, dialog_generator.php had changed from 1.2.6.2, but i don't see it in the dev branch anymore

meant to make this a different branch, but i messed it up.

didn't add in timezone to the user preferences page yet, i was testing it with my settings hooks (coming next pull).

it was really quite easy to add the per-user timezones with the way you had the code structured. :)
