### PR TITLE
Allow login with HTTP Authorization header

### DIFF
--- a/web/app/controllers.php
+++ b/web/app/controllers.php
@@ -7,6 +7,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Silex\Application;
 
+use AgenDAV\Controller\Authentication;
 use AgenDAV\DateHelper;
 
 // Authentication
@@ -66,6 +67,13 @@ $controllers->before(function(Request $request, Silex\Application $app) {
         $request->setLocale($preferences->get('language'));
         $app['translator']->setLocale($preferences->get('language'));
         return;
+    }
+
+    if ($request->headers->get('authorization') != null) {
+        $authController = new Authentication();
+        if ($authController->processLogin($request->headers->get('php-auth-user'), $request->headers->get('php-auth-pw'), $app)) {
+            return;
+        }
     }
 
     if ($request->isXmlHttpRequest()) {

--- a/web/app/controllers.php
+++ b/web/app/controllers.php
@@ -7,7 +7,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Silex\Application;
 
-use AgenDAV\Controller\Authentication;
 use AgenDAV\DateHelper;
 
 // Authentication
@@ -69,10 +68,11 @@ $controllers->before(function(Request $request, Silex\Application $app) {
         return;
     }
 
-    if ($request->headers->get('authorization') != null) {
-        $authController = new Authentication();
-        if ($authController->processLogin($request->headers->get('php-auth-user'), $request->headers->get('php-auth-pw'), $app)) {
-            return;
+    if (isset($app['auth.methods'])) {
+        foreach ($app['auth.methods'] as $method) {
+            if (call_user_func([$method, 'login'], $request, $app)) {
+                return;
+            }
         }
     }
 

--- a/web/config/default.settings.php
+++ b/web/config/default.settings.php
@@ -155,3 +155,5 @@ $app['calendar.colors'] = [
     'F5F5F5', // Pale gray
 ];
 
+// Additionnal authentication methods
+//$app['auth.methods'] = ['AgenDAV\Authentication\HttpBasic'];

--- a/web/src/Authentication/AuthenticationMethodInterface.php
+++ b/web/src/Authentication/AuthenticationMethodInterface.php
@@ -1,0 +1,19 @@
+<?php
+namespace AgenDAV\Authentication;
+
+use Silex\Application;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Interace used to implement new authentication methods
+ */
+interface AuthenticationMethodInterface
+{
+    /**
+     * Use this authentication method to login
+     * @param  Request     $request HTTP request
+     * @param  Application $app     Application object
+     * @return bool                 true if login is successful, false otherwise
+     */
+    public static function login(Request $request, Application $app);
+}

--- a/web/src/Authentication/HttpBasic.php
+++ b/web/src/Authentication/HttpBasic.php
@@ -1,0 +1,33 @@
+<?php
+namespace AgenDAV\Authentication;
+
+use AgenDAV\Controller\Authentication;
+use Silex\Application;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Authentication method using HTTP basic authentication
+ */
+class HttpBasic implements AuthenticationMethodInterface
+{
+    /**
+     * Try to login using the Authorization HTTP header
+     * @param  Request     $request HTTP request
+     * @param  Application $app     Application object
+     * @return bool                 true if login is successful, false otherwise
+     */
+    public static function login(Request $request, Application $app)
+    {
+        if ($request->headers->get('authorization') != null) {
+            $authController = new Authentication();
+            if ($authController->processLogin(
+                $request->headers->get('php-auth-user'),
+                $request->headers->get('php-auth-pw'),
+                $app
+            )) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/web/src/Controller/Authentication.php
+++ b/web/src/Controller/Authentication.php
@@ -83,7 +83,7 @@ class Authentication
      * @param Application $app
      * @return bool false if authentication failed, true otherwise
      */
-    protected function processLogin($user, $password, Application $app)
+    public function processLogin($user, $password, Application $app)
     {
         $app['http.client']->setAuthentication($user, $password, $app['caldav.authmethod']);
 


### PR DESCRIPTION
Hello,

We're working on a way to integrate Agendav into our web app and we want to access the JSON API but currently Agendav only supports login via the login form.
So we patched it to accept HTTP `Authorization` headers as well.
This allows us to access the API directly by providing the credentials in the request:
```bash
curl https://foo:bar@agendav.example.com/calendars
```

Is this something you would be interested in merging upstream?

Regards,