### PR TITLE
Iframe view

### DIFF
--- a/assets/less/agendav.less
+++ b/assets/less/agendav.less
@@ -407,4 +407,11 @@ div.container_repeat_options {
     display: none;
 }
 
+.iframe {
+    #content {
+        width: auto;
+        padding: 5px;
+    }
+}
+
 // vim: ft=css sw=2 tabstop=2 expandtab

--- a/web/app/controllers.php
+++ b/web/app/controllers.php
@@ -25,6 +25,9 @@ $controllers->get('/', function () use ($app) {
     return $app['twig']->render('calendar.html');
 })
 ->bind('calendar');
+$controllers->get('/iframe', function () use ($app) {
+    return $app['twig']->render('calendar_iframe.html');
+});
 
 $controllers->get('/preferences', '\AgenDAV\Controller\Preferences::indexAction')->bind('preferences');
 $controllers->post('/preferences', '\AgenDAV\Controller\Preferences::saveAction')->bind('preferences.save');

--- a/web/templates/calendar_iframe.html
+++ b/web/templates/calendar_iframe.html
@@ -1,0 +1,14 @@
+{% extends 'calendar.html' %}
+
+{% block content %}
+  <div class="calendar_list hidden" id="own_calendar_list"><ul></ul></div>
+  <div class="container-fluid iframe">
+   <div class="wrapper">
+
+    <div id="content">
+      <div id="calendar_view"></div>
+    </div>
+
+   </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
Now that #212 is merged, we integrate Agendav into one of our web apps.
But we needed a way to display a simplified version into an iframe.
So this PR adds a new `/iframe` route that only shows the calendar (no header or sidebar).

(Note that I add to include a hidden `calendar_list` element since it is used by the JS to store the calendar states.)