### PR TITLE
Show calendars that we have proxy access to

### DIFF
--- a/web/src/CalDAV/Client.php
+++ b/web/src/CalDAV/Client.php
@@ -342,6 +342,38 @@ class Client
     }
 
     /**
+     * get proxy-for principal home uris
+     */
+    public function getProxyFor($url)
+    {
+        $propRead = '{http://calendarserver.org/ns/}calendar-proxy-read-for';
+        $propWrite = '{http://calendarserver.org/ns/}calendar-proxy-write-for';
+        $props = [ $propRead, $propWrite ];
+
+        $xml_body = $this->xml_toolkit->generateRequestBody('EXPAND-PROPERTY', $props);
+        $data = $this->report($url, $xml_body);
+
+        if (isset($data[$url]))
+            $data = $data[$url];
+        else
+            $data = [];
+
+        $proxyFor = [];
+        foreach ($props as $prop) {
+            if (!isset($data[$prop]))
+                continue;
+            foreach ($data[$prop] as $resp) {
+                if ( $resp["name"] != "{DAV:}response" )
+                    continue;
+                $href = $resp["value"]->getHref();
+                $proxyFor[] = $href;
+            }
+        }
+
+        return $proxyFor;
+    }
+
+    /**
      * Issues a PROPFIND and parses the response
      *
      * @param string $url   URL

--- a/web/src/CalendarFinder.php
+++ b/web/src/CalendarFinder.php
@@ -84,6 +84,15 @@ class CalendarFinder
             $calendar->setOwner($this->current_principal);
         }
 
+        $urls = $this->client->getProxyFor($calendar_home_set);
+        foreach ($urls as $url) {
+            $other_calendars = $this->client->getCalendars($url);
+            foreach ($other_calendars as $calendar) {
+                $calendar->setOwner($this->current_principal); # FIXME: this is required to avoid null ptr exception
+            }
+            $calendars = array_merge($calendars, $other_calendars);
+        }
+
         if ($this->sharing_enabled) {
             // Add share info to own calendars
             $this->addShares($calendars);

--- a/web/src/XML/Generator.php
+++ b/web/src/XML/Generator.php
@@ -58,6 +58,32 @@ class Generator
     }
 
     /**
+     * Generates a EXPAND-PROPERTY body
+     *
+     * @param array $properties List of properties, specified using Clark notation
+     * @return string           XML body for the propfind request
+     */
+    public function expandPropertyBody(array $properties)
+    {
+        $writer = $this->createNewWriter();
+        $writer->startElement('{DAV:}expand-property');
+
+        foreach ($properties as $property) {
+           $writer->startElement('{DAV:}property');
+            list(
+                $namespace,
+                $localName
+            ) = \Sabre\Xml\Service::parseClarkNotation($property);
+           $writer->writeAttribute('name', $localName);
+           $writer->writeAttribute('namespace', $namespace);
+           $writer->endElement();
+        }
+        $writer->endElement();
+
+        return $writer->outputMemory();
+    }
+
+    /**
      * Generates a PROPFIND body
      *
      * @param array $properties List of properties, specified using Clark notation

--- a/web/src/XML/Toolkit.php
+++ b/web/src/XML/Toolkit.php
@@ -75,8 +75,8 @@ class Toolkit
     /**
      * Generates the XML body for a request
      *
-     * @param string $request   One of MKCALENDAR, PROPFIND, PROPPATCH, REPORT-CALENDAR or
-     *                          REPORT-PRINCIPAL-SEARCH
+     * @param string $request   One of MKCALENDAR, PROPFIND, PROPPATCH, REPORT-CALENDAR,
+     *                          REPORT-PRINCIPAL-SEARCH or EXPAND-PROPERTY
      * @param mixed $parameters array of properties, \AgenDAV\CalDAV\ComponentFilter
      *                          object if $request is REPORT or \AgenDAV\CalDAV\Share\ACL
      *                          if $request is ACL
@@ -86,6 +86,8 @@ class Toolkit
     public function generateRequestBody($request, $parameters)
     {
         switch ($request) {
+            case 'EXPAND-PROPERTY':
+                return $this->generator->expandPropertyBody($parameters);
             case 'MKCALENDAR':
                 return $this->generator->mkCalendarBody($parameters);
             case 'PROPFIND':


### PR DESCRIPTION
If other principals grant calendar access to us, they show up in our
calendar-proxy-(read|write)-for properties.

Use these properties to display those calendars automatically.