### PR TITLE
Add a lang attribute on the html tag

### DIFF
--- a/web/app/app.php
+++ b/web/app/app.php
@@ -37,6 +37,7 @@ $app['twig'] = $app->extend('twig', function ($twig, $app) {
     $twig->addGlobal('logo', $app['site.logo']);
     $twig->addGlobal('favicon', $app['site.favicon']);
     $twig->addGlobal('footer', $app['site.footer']);
+    $twig->addGlobal('lang', $app['translator']->getLocale());
 
     // Assets
     $twig->addGlobal('stylesheets', $app['stylesheets']);

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ lang }}">
     <head>
         <title>{{ title }}</title>
         <link rel="shortcut icon" href="{{ asset(favicon, 'img') }}" />


### PR DESCRIPTION
This patch adds a `lang` attribute that is used by search engines and screen readers to get the language of the current page.