### PR TITLE
CalDAV:applyACL() the request must have Content-Type XML

### DIFF
--- a/web/src/CalDAV/Client.php
+++ b/web/src/CalDAV/Client.php
@@ -342,6 +342,7 @@ class Client
     public function applyACL(Calendar $calendar, ACL $acl)
     {
         $url = $calendar->getUrl();
+        $this->http_client->setContentTypeXML();
         $body = $this->xml_toolkit->generateRequestBody('ACL', $acl);
 
         return $this->http_client->request('ACL', $url, $body);


### PR DESCRIPTION
otherwise Cyrus IMAP rejects the request.

Closes https://github.com/agendav/agendav/issues/252.