### PR TITLE
Remove the duplicated line in documentation

### DIFF
--- a/doc/source/admin/installation.rst
+++ b/doc/source/admin/installation.rst
@@ -17,7 +17,6 @@ AgenDAV |release| requires the following software to be installed:
 
   * ctype
   * curl
-  * curl
   * mbstring
   * mcrypt
   * tokenizer


### PR DESCRIPTION
"curl" was listed twice in the documentation as a requirement.