### PR TITLE
inline AgenDAVConf/UserPrefs into calendar page

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -24,7 +24,18 @@ return function (App $app) {
     // Authenticated routes
     $app->group('', function (RouteCollectorProxy $g) use ($container) {
         $g->get('/', function (ServerRequestInterface $request, ResponseInterface $response) use ($container) {
-            $body = $container->get('twig')->render('calendar.html');
+            // Inline AgenDAVConf/UserPrefs into the page so the JS bootstrap does
+            // not depend on a separate /jssettings request. Some SSO/reverse-proxy
+            // setups (notably YunoHost) gate extensionless URLs as protected pages
+            // even when the parent navigation is allowed, breaking <script src>.
+            $jsCode = new JavaScriptCode($container);
+            $jsconfig = $container->get('twig')->render('jsconfig.html', [
+                'site_config' => $jsCode->getSiteConfig($request),
+                'preferences' => $jsCode->getPreferences(),
+            ]);
+            $body = $container->get('twig')->render('calendar.html', [
+                'jsconfig' => $jsconfig,
+            ]);
             $response->getBody()->write($body);
             return $response;
         })->setName('calendar');

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "license": "GPL-3.0-or-later",
     "require": {
         "php": ">=8.5",
-        "doctrine/common": "^3.4",
         "doctrine/dbal": "^4.0",
         "doctrine/migrations": "^3.8",
         "doctrine/orm": "^3.0",
@@ -19,7 +18,6 @@
         "sabre/dav": "^4.6",
         "slim/psr7": "^1.6",
         "slim/slim": "^4.14",
-        "slim/twig-view": "^3.4",
         "symfony/asset": "^7.4",
         "symfony/cache": "^7.4",
         "symfony/console": "^7.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "313ab38040c5ce1dd1226aa9bd7e8efb",
+    "content-hash": "5739a4d9e1de88b012605d3d4b858ec2",
     "packages": [
         {
             "name": "brick/math",
@@ -151,97 +151,6 @@
                 }
             ],
             "time": "2026-01-15T10:01:58+00:00"
-        },
-        {
-            "name": "doctrine/common",
-            "version": "3.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/common.git",
-                "reference": "d9ea4a54ca2586db781f0265d36bea731ac66ec5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/common/zipball/d9ea4a54ca2586db781f0265d36bea731ac66ec5",
-                "reference": "d9ea4a54ca2586db781f0265d36bea731ac66ec5",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/persistence": "^2.0 || ^3.0 || ^4.0",
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9.0 || ^10.0",
-                "doctrine/collections": "^1",
-                "phpstan/phpstan": "^1.4.1",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5.20 || ^8.5 || ^9.0",
-                "squizlabs/php_codesniffer": "^3.0",
-                "symfony/phpunit-bridge": "^6.1",
-                "vimeo/psalm": "^4.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                },
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                }
-            ],
-            "description": "PHP Doctrine Common project is a library that provides additional functionality that other Doctrine projects depend on such as better reflection support, proxies and much more.",
-            "homepage": "https://www.doctrine-project.org/projects/common.html",
-            "keywords": [
-                "common",
-                "doctrine",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/common/issues",
-                "source": "https://github.com/doctrine/common/tree/3.5.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcommon",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-01-01T22:12:03+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -3160,71 +3069,6 @@
             "time": "2026-05-22T08:00:12+00:00"
         },
         {
-            "name": "slim/twig-view",
-            "version": "3.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/slimphp/Twig-View.git",
-                "reference": "b4268d87d0e327feba5f88d32031e9123655b909"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/slimphp/Twig-View/zipball/b4268d87d0e327feba5f88d32031e9123655b909",
-                "reference": "b4268d87d0e327feba5f88d32031e9123655b909",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0",
-                "psr/http-message": "^1.1 || ^2.0",
-                "slim/slim": "^4.12",
-                "symfony/polyfill-php81": "^1.29",
-                "twig/twig": "^3.11"
-            },
-            "require-dev": {
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpstan/phpstan": "^1.10.59",
-                "phpunit/phpunit": "^9.6 || ^10",
-                "psr/http-factory": "^1.0",
-                "squizlabs/php_codesniffer": "^3.9"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Slim\\Views\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Josh Lockhart",
-                    "email": "hello@joshlockhart.com",
-                    "homepage": "http://joshlockhart.com"
-                },
-                {
-                    "name": "Pierre Berube",
-                    "email": "pierre@lgse.com",
-                    "homepage": "http://www.lgse.com"
-                }
-            ],
-            "description": "Slim Framework 4 view helper built on top of the Twig 3 templating component",
-            "homepage": "https://www.slimframework.com",
-            "keywords": [
-                "framework",
-                "slim",
-                "template",
-                "twig",
-                "view"
-            ],
-            "support": {
-                "issues": "https://github.com/slimphp/Twig-View/issues",
-                "source": "https://github.com/slimphp/Twig-View/tree/3.4.1"
-            },
-            "time": "2024-09-26T05:42:02+00:00"
-        },
-        {
             "name": "symfony/asset",
             "version": "v7.4.8",
             "source": {
@@ -4222,86 +4066,6 @@
                 }
             ],
             "time": "2026-05-26T12:51:13+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php81",
-            "version": "v1.38.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
-                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php81\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.38.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-26T12:45:58+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
@@ -8480,6 +8244,86 @@
             "time": "2026-04-10T16:19:22+00:00"
         },
         {
+            "name": "symfony/polyfill-php81",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T12:45:58+00:00"
+        },
+        {
             "name": "symfony/process",
             "version": "v8.1.0",
             "source": {
@@ -8604,5 +8448,5 @@
         "php": ">=8.5"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/resources/private/templates/parts/agendavjs.html
+++ b/resources/private/templates/parts/agendavjs.html
@@ -1,6 +1,6 @@
-<script language="JavaScript" type="text/javascript" src="{{ url_for('settings.js') }}"></script>
 <script language="JavaScript" type="text/javascript">
 //<![CDATA[
+{{ jsconfig|raw }}
 var translations = {{ translations|js_json }};
 var csrf_id = '_token';
 var csrf_value = {{ csrf_token.getValue()|js_json }};

--- a/src/Controller/JavaScriptCode.php
+++ b/src/Controller/JavaScriptCode.php
@@ -53,7 +53,7 @@ class JavaScriptCode
     /**
      * @return array<string, mixed>
      */
-    protected function getSiteConfig(ServerRequestInterface $request): array
+    public function getSiteConfig(ServerRequestInterface $request): array
     {
         // Derive base URLs from Slim's RouteParser rather than $_SERVER['SCRIPT_NAME'].
         // Behind a misconfigured reverse proxy SCRIPT_NAME can be attacker-
@@ -89,7 +89,7 @@ class JavaScriptCode
     /**
      * @return array<string, mixed>
      */
-    protected function getPreferences(): array
+    public function getPreferences(): array
     {
         return $this->container->get(UserContext::class)->getPreferences()->getAll();
     }


### PR DESCRIPTION
Some reverse-proxy / SSO setups (notably YunoHost 12) gate extensionless URLs as protected pages even when the parent navigation is allowed, which breaks the <script src="/jssettings"> bootstrap: the script tag follows a redirect to the SSO portal, receives HTML, and the browser refuses to execute it for nosniff/MIME-mismatch — leaving AgenDAVConf undefined and the calendar sidebar permanently empty.

Render jsconfig.html on the server when handling the calendar route and include its output inline in the existing <script> block in parts/agendavjs.html. No /jssettings sub-request is needed.

The /jssettings route is kept in place for backward compatibility but nothing references it anymore.

Drop unused direct dependencies doctrine/common and slim/twig-view, since neither is referenced in the source: the twig service is built directly from \Twig\Loader\FilesystemLoader + \Twig\Environment (app/services.php) rather than via slim/twig-view, and there are no Doctrine\Common usages.
Nothing else requires them transitively, so composer removes them cleanly.