### PR TITLE
Relax DAV capability check for authentication

### DIFF
--- a/src/CalDAV/Client.php
+++ b/src/CalDAV/Client.php
@@ -71,8 +71,12 @@ class Client
             return false;
         }
 
-        return ($response->hasHeader('DAV') &&
-            false !== strpos($response->getHeaderLine('DAV'), "calendar-access"));
+        // A successful DAV response is sufficient here.
+        // Authentication is fully validated afterwards by requesting the
+        // current-user-principal and calendar-home-set.
+        return $response->getStatusCode() >= 200
+            && $response->getStatusCode() < 300
+            && $response->hasHeader('DAV');
     }
 
     /**


### PR DESCRIPTION
## Summary

`Client::canAuthenticate()` currently requires the `DAV` response header to contain the `calendar-access` capability.

This is more restrictive than necessary and prevents authentication against some CalDAV servers, including current Nextcloud (SabreDAV) installations. These servers return a valid `DAV` response header but do not include the `calendar-access` capability.

The login flow already validates the authenticated CalDAV server immediately afterwards by resolving `current-user-principal` and `calendar-home-set`.

This change accepts any successful DAV response instead of requiring the `calendar-access` capability.

## Why this change?

The current authentication flow is:

1. Send an `OPTIONS` request.
2. Check for `calendar-access` in the `DAV` response header.
3. Resolve `current-user-principal`.
4. Resolve `calendar-home-set`.

Steps 3 and 4 already verify that the server is a functional CalDAV server and that authentication succeeded. Therefore, requiring the `calendar-access` capability does not provide additional validation while unnecessarily rejecting compatible servers.

## Tested with

- AgenDAV 3.2.0
- Nextcloud Hub 10 (Nextcloud 33)
- PHP 8.5

The complete authentication flow was verified successfully after this change.