### PR TITLE
Add optional automatic login

### DIFF
--- a/config/default.settings.php
+++ b/config/default.settings.php
@@ -183,6 +183,11 @@ return [
     // Additional authentication methods (FQCNs implementing AuthenticationMethodInterface)
     'auth.methods' => [],
 
+    // Automatically log in to the CalDAV backend with configured credentials
+    'autologin.enabled' => false,
+    'autologin.username' => '',
+    'autologin.password' => '',
+
     // HTTP debug logging
     'http.debug' => false,
 

--- a/src/Controller/Authentication.php
+++ b/src/Controller/Authentication.php
@@ -37,11 +37,12 @@ class Authentication
         ResponseInterface $response
     ): ResponseInterface {
         $template_vars = [];
+        $session = $this->container->get('session');
 
         // GET: try alternative auth methods (HTTP Basic, ...) before showing
         // the form. Lets clients that follow a 302 redirect chain authenticate
         // transparently with credentials already on the request.
-        if ($request->getMethod() === 'GET' && !$this->container->get('session')->has('username')) {
+        if ($request->getMethod() === 'GET' && !$session->has('username')) {
             foreach ((array) $this->container->get('auth.methods') as $methodClass) {
                 if ($this->container->get($methodClass)->login($request)) {
                     /** @var RouteParserInterface $routeParser */
@@ -50,6 +51,28 @@ class Authentication
                         ->withStatus(302)
                         ->withHeader('Location', $routeParser->urlFor('calendar'));
                 }
+            }
+
+            $autologinUser = (string) $this->container->get('autologin.username');
+            $autologinPassword = (string) $this->container->get('autologin.password');
+            // Automatically authenticate a dedicated dashboard account when enabled.
+            // Falls back to the regular login page if authentication fails.
+            if (
+                $this->container->get('autologin.enabled') === true
+                && $autologinUser !== ''
+                && $autologinPassword !== ''
+            ) {
+                $logContext = ['user' => substr($autologinUser, 0, 64)];
+                if ($this->processLogin($autologinUser, $autologinPassword)) {
+                    $this->container->get('monolog')->info('Automatic login succeeded', $logContext);
+                    /** @var RouteParserInterface $routeParser */
+                    $routeParser = $this->container->get(RouteParserInterface::class);
+                    return $response
+                        ->withStatus(302)
+                        ->withHeader('Location', $routeParser->urlFor('calendar'));
+                }
+
+                $this->container->get('monolog')->warning('Automatic login failed', $logContext);
             }
         }
 


### PR DESCRIPTION
## Summary

Add optional automatic login using a dedicated service account.

When enabled in the configuration, AgenDAV automatically authenticates the configured user and skips the login page.

The feature is disabled by default and has no effect unless explicitly configured.

## Configuration

```php
'autologin.enabled' => true,
'autologin.username' => 'calendar',
'autologin.password' => 'secret',
