### PR TITLE
Show calendar name in event tooltips

### DIFF
--- a/resources/private/assets/js/app/app.js
+++ b/resources/private/assets/js/app/app.js
@@ -1690,11 +1690,14 @@ var event_render_callback = function event_render_callback(event, element) {
     element.find('.fc-title').append(icon_html);
   }
 
-  // Hover tooltip with full time and title
+  // Hover tooltip with calendar name, full time and title
   var fmt = AgenDAVDateAndTime.momentFormat[AgenDAVUserPrefs.time_format];
-  var tooltip = event.allDay
-    ? event.title
-    : event.start.format(fmt) + ' - ' + event.end.format(fmt) + ' ' + event.title;
+  var tooltip = '[' + get_calendar_displayname(event.calendar) + '] ';
+  if (event.start && event.end) {
+    tooltip += event.start.format(fmt) + ' - ' + event.end.format(fmt) + ' ' + event.title;
+  } else {
+    tooltip += event.title;
+  }
   element.attr('title', tooltip);
 
 };


### PR DESCRIPTION
## Summary

Prefix event hover tooltips with the calendar display name.

This helps users identify the source calendar when viewing many shared calendars at once.

Example:

```text
[Calendar name] 10:30 - 11:30 Event title
