### PR TITLE
Sort calendar list by server order

### DIFF
--- a/resources/private/assets/js/app/app.js
+++ b/resources/private/assets/js/app/app.js
@@ -1205,6 +1205,24 @@ var update_calendar_list = function update_calendar_list(maskbody) {
 
     var calendars = data.data;
 
+    calendars.sort(function(a, b) {
+      var order_a = parseInt(a.order, 10);
+      var order_b = parseInt(b.order, 10);
+
+      if (isNaN(order_a)) {
+        order_a = 0;
+      }
+      if (isNaN(order_b)) {
+        order_b = 0;
+      }
+
+      if (order_a !== order_b) {
+        return order_a - order_b;
+      }
+
+      return (a.displayname || '').localeCompare(b.displayname || '');
+    });
+
     $.each(calendars, function(key, calendar) {
       // This is a hidden calendar
       if (AgenDAVUserPrefs.hidden_calendars[calendar.calendar] !== undefined) {


### PR DESCRIPTION
## Summary

Sort the calendar list by the CalDAV `calendar-order` value before rendering it.

AgenDAV already reads `calendar-order` from the CalDAV server and exposes it as `order` in the calendar list JSON response. This change uses that value in the frontend so the sidebar calendar list follows the server-provided order.

When multiple calendars have the same order value, the display name is used as a stable fallback sort key.

## Notes

The existing grouping remains unchanged:

- owned calendars
- shared calendars
- subscribed calendars

The sort order is applied before rendering, so calendars are ordered within their rendered groups.